### PR TITLE
added rows and cols to separator logic

### DIFF
--- a/src/Separators/Line.js
+++ b/src/Separators/Line.js
@@ -8,13 +8,14 @@ const Line = ({ position, locations, direction }) => {
   const lineLength = 11;
   const strokeWidth = 4;
   if (direction === 'across') {
-    x1 = position.x + (locations[0] * CELL_WIDTH);
-    x2 = x1 + lineLength;
+    y1 = ((position.y + 1) * CELL_WIDTH) - (CELL_WIDTH / 3);
     y2 = y1;
+    x1 = (position.x + locations[0]) * CELL_WIDTH;
+    x2 = x1 + lineLength;
   } else {
-    x1 = (position.x * (CELL_WIDTH + 1)) + (CELL_WIDTH / 2) + 1;
+    x1 = ((position.x + 1) * CELL_WIDTH) - (CELL_WIDTH / 3);
     x2 = x1;
-    y1 = (position.y - 1) + (locations[0] * CELL_WIDTH);
+    y1 = (position.y + locations[0]) * CELL_WIDTH;
     y2 = y1 + lineLength;
   }
   return (


### PR DESCRIPTION
so that separators not starting from top row or leftmost column end up in the right place.
Also found a bug where the code doesn't support multiple separators, but I couldn't find a fix for that at the moment. 